### PR TITLE
Example improvements 2

### DIFF
--- a/examples/math/colorcube.html
+++ b/examples/math/colorcube.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>MathBox - Color Cube</title>
+  <script src="../../build/mathbox-bundle.js"></script>
+  <link rel="stylesheet" href="../../build/mathbox.css">
+  <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+</head>
+<body>
+  <script>
+    mathbox = mathBox({
+      plugins: ['core', 'controls', 'cursor'],
+      controls: {
+        klass: THREE.OrbitControls,
+      },
+      camera: {
+      }
+    });
+
+    three = mathbox.three;
+    three.controls.maxDistance = 4;
+    three.camera.position.set(2.5, 1, 2.5);
+    three.renderer.setClearColor(new THREE.Color(0xEEEEEE), 1.0);
+
+    view = mathbox
+    .set({
+      scale: 720,
+      focus: 1
+    })
+    .cartesian({
+      range: [[0, 1], [0, 1], [0, 1]],
+      scale: [1, 1, 1],
+    })
+
+    var rez = 10;
+    view.volume({
+      id: "volume",
+      width: rez,
+      height: rez,
+      depth: rez,
+      items: 1,
+      channels: 4,
+      expr: function(emit, x, y, z){
+          emit(x,y,z,1);
+      }
+    })
+    view.point({
+      // The neat trick: use the same data for position and for color!
+      // We don't actually need to specify the points source since we just defined them
+      // but it emphasizes what's going on.
+      // The w component 1 is ignored as a position but used as opacity as a color.
+      points: "#volume",
+      colors: "#volume",
+      // Multiply every color component in [0..1] by 255
+      color: 0xffffff,
+      size: 20,
+    });
+
+  </script>
+</body>
+</html>

--- a/examples/test/axis.html
+++ b/examples/test/axis.html
@@ -23,11 +23,6 @@
     three.camera.position.set(-.15, .15, 3.6);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    three.on('update', function () {
-      var d = .5 + .5 * Math.sin(three.Time.now * .5);
-      depthObj.set('depth', d);
-    });
-
     colors = {
       x: new THREE.Color(0xFF4136),
       y: new THREE.Color(0x2ECC40),
@@ -44,24 +39,23 @@
       scale: [2, 1, 1],
     });
     view.axis({
-      end: true,
-      width: 5,
       color: colors.x,
     });
     view.axis({
       axis: 2, // "y" also works
-      end: true,
-      width: 5,
       color: colors.y,
     });
     view.axis({
       axis: 3,
-      end: true,
-      width: 5,
       color: colors.z,
     });
 
-    var depthObj = mathbox.select('axis');
+    mathbox.select('axis')
+      .set('end', true)
+      .set('width', 5)
+      .bind('depth', function(t){
+          return .5 + .5 * Math.sin(t * .5);
+      })
 
     view.array({
       id: "colors",

--- a/examples/test/cartesian4.html
+++ b/examples/test/cartesian4.html
@@ -20,11 +20,6 @@
     three.camera.position.set(2.3, 1, 2);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.now
-    });
-
     view = mathbox.transform4({
       matrix: [
         1, 0, 0, .577,
@@ -63,7 +58,7 @@
       rangeY: [-1, 1],
       width: 32,
       height: 8,
-      expr: function (emit, x, y, i, j) {
+      expr: function (emit, x, y, i, j, time) {
         θ = π / 2 * (
               Math.cos(time * .31 + Math.cos(time * .481 - Math.sin(time * .318)) + Math.sin(time * 1.179))
             + Math.cos(time * .61 - Math.sin(time * .305 - Math.cos(time * .573)) + Math.cos(time * 0.962))
@@ -100,7 +95,7 @@
       rangeY: [-1, 1],
       width: 96,
       height: 8,
-      expr: function (emit, x, y, i, j) {
+      expr: function (emit, x, y, i, j, time) {
         θ = π / 2 * (
               Math.cos(time * .31 + Math.cos(time * .481 - Math.sin(time * .318)) + Math.sin(time * 1.179))
             + Math.cos(time * .61 - Math.sin(time * .305 - Math.cos(time * .573)) + Math.cos(time * 0.962))

--- a/examples/test/curvedots.html
+++ b/examples/test/curvedots.html
@@ -20,11 +20,6 @@
     three.camera.position.set(0, 0, 3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock
-    });
-
     view = mathbox.cartesian({
       range: [[-2, 2], [-1, 1], [-1, 1]],
       scale: [2, 1, 1],
@@ -33,7 +28,7 @@
     view.interval({
       id: 'sampler',
       length: 32,
-      expr: function (emit, x, i) {
+      expr: function (emit, x, i, time) {
         y = Math.sin(x + time) + (i%2)*Math.sin(x * 400000 + time * 5 + x * x * 10000)*.05;
         emit(x, y);
       },
@@ -44,7 +39,7 @@
       unit: 'absolute',
       height: [0, .05, 0, 0],
     });
-    
+
     view.split({
       axis:    'x',
       length:  3,

--- a/examples/test/data.html
+++ b/examples/test/data.html
@@ -34,13 +34,6 @@
       return Math.floor(x * data.length / 2) * 2
     };
 
-    clamp = function (x) { return Math.max(0, Math.min(1, x)); };
-
-    rand = function (seed, i) {
-      var r = Math.sin(seed + i * 100) * 11.0;
-      return r - Math.floor(r);
-    };
-
     time = 0
     three.on('update', function () {
       time = three.Time.frames / 200

--- a/examples/test/dom-clone.html
+++ b/examples/test/dom-clone.html
@@ -26,7 +26,7 @@
         return button;
       },
     });
-    
+
     mathbox = mathBox({
       plugins: ['core', 'controls', 'cursor', 'stats'],
       controls: {
@@ -42,11 +42,6 @@
     three.camera.position.set(1.1, 1.45, 1);
     three.camera.lookAt(new THREE.Vector3())
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
-
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock * .2;
-    });
 
     view = mathbox
     .set({
@@ -80,8 +75,8 @@
 
     view.interval({
       length: 8,
-      expr: function (emit, x, i) {
-        y = Math.sin(x + time / 4) * .7;
+      expr: function (emit, x, i, time) {
+        y = Math.sin(x + (time*0.2) / 4) * .7;
         emit(x, y);
       },
       channels: 2,

--- a/examples/test/dom-latex.html
+++ b/examples/test/dom-latex.html
@@ -11,7 +11,7 @@
 </head>
 <body>
   <script>
-  
+
     // Define global DOM handler to format 'latex' into an HTML span
     MathBox.DOM.Types.latex = MathBox.DOM.createClass({
       render: function (el) {
@@ -19,7 +19,7 @@
         return el('span', this.props);
       }
     });
-  
+
     mathbox = mathBox({
       plugins: ['core', 'controls', 'cursor', 'stats'],
       controls: {
@@ -35,11 +35,6 @@
     three.camera.position.set(1.1, 1.45, 1);
     three.camera.lookAt(new THREE.Vector3())
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
-
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock * .2;
-    });
 
     view = mathbox
     .unit({
@@ -73,8 +68,8 @@
 
     view.interval({
       length: 8,
-      expr: function (emit, x, i) {
-        y = Math.sin(x + time / 4) * .7;
+      expr: function (emit, x, i, time) {
+        y = Math.sin(x + (time*0.2) / 4) * .7;
         emit(x, y);
       },
       channels: 2,

--- a/examples/test/dom-vdom.html
+++ b/examples/test/dom-vdom.html
@@ -25,11 +25,6 @@
     three.camera.lookAt(new THREE.Vector3())
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock * .2;
-    });
-
     view = mathbox
     .unit({
       scale: null,
@@ -62,8 +57,8 @@
 
     view.interval({
       length: 16,
-      expr: function (emit, x, i) {
-        y = Math.sin(x + time / 4) * .7;
+      expr: function (emit, x, i, time) {
+        y = Math.sin(x + (time*0.2) / 4) * .7;
         emit(x, y);
       },
       channels: 2,
@@ -89,12 +84,13 @@
       width: 16,
       height: 5,
       depth:  2,
-      expr: function (emit, el, i, j) {
+      expr: function (emit, el, i, j, time) {
+        time *= 0.2;
         var color = ['#c02050','#50c020'][i%2];
         emit([
           el('span', {style: {color: color}}, Math.floor(time * 2 + i / 8)),
           el('strong', null,
-            String.fromCharCode(j + 65) + 
+            String.fromCharCode(j + 65) +
             String.fromCharCode(i + 0x8000 + Math.floor(time + i/8)%100 * 3)
           )
         ]);

--- a/examples/test/feedback.html
+++ b/examples/test/feedback.html
@@ -19,17 +19,6 @@
 
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0;
-    origin = new THREE.Vector3();
-    three.on('update', function (event) {
-      time = three.Time.clock;
-      x = Math.cos(time) * 3;
-      z = Math.sin(time) * 3;
-
-      camera.set('position', [x, 0, z]);
-      camera.set('lookAt', origin);
-    });
-
     view = mathbox
     .set({
       focus: 3
@@ -38,7 +27,11 @@
       type: 'float',
     })
     .camera({
-      position: [0, 0, 3]
+      lookAt: [0, 0, 0]
+      }, {
+      position: function(t){
+          return [Math.cos(t)*3, 0, Math.sin(t)*3]
+      }
     })
     .compose({
       color: '#fcfbfa',
@@ -52,8 +45,6 @@
       divideY: 2,
       opacity: .25,
     });
-
-    var camera = mathbox.select('camera');
 
     mathbox.compose({
       color: '#fff',

--- a/examples/test/format.html
+++ b/examples/test/format.html
@@ -23,14 +23,6 @@
     three.camera.position.set(1, 1, 3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    three.on('update', function () {
-      var d = .5 + .5 * Math.sin(three.Time.now * .25);
-      var v = .5 - .5 * Math.sin(three.Time.now * 2);
-      v = 20 * v * v;
-      depthObj.set('depth', d);
-      view.set('range', [[-2 - v, 2 + v], [-1, 1], [-1, 1]]);
-    });
-
     view = mathbox
     .set({
       scale: 950,
@@ -38,8 +30,13 @@
       fov: 45
     })
     .cartesian({
-      range: [[-2, 2], [-1, 1], [-1, 1]],
       scale: [2, 1, 1],
+    },{
+      range: function(t){
+          var v = .5 - .5 * Math.sin(t * 2);
+          v = 20 * v * v;
+          return [[-2 - v, 2 + v], [-1, 1], [-1, 1]];
+      }
     });
 
     view.axis({
@@ -58,7 +55,7 @@
       width: 5,
     });
 
-    
+
     view.scale({
       divide: 10,
     });
@@ -74,7 +71,10 @@
       depth: 1,
     });
 
-    var depthObj = mathbox.select('axis, ticks, label');
+    mathbox.select('axis, ticks, label')
+      .bind('depth', function(t){
+        return .5 + .5 * Math.sin(t * .25);
+      })
 
   </script>
 </body>

--- a/examples/test/helix.html
+++ b/examples/test/helix.html
@@ -20,11 +20,6 @@
     three.camera.position.set(2.3, 1, 2);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.now
-    });
-
     view = mathbox.cartesian({
       range: [[-6, 6], [-1, 1], [-1, 1]],
       scale: [6, 1, 1],
@@ -38,7 +33,7 @@
 
     view.interval({
       length: 128,
-      expr: function (emit, x, i) {
+      expr: function (emit, x, i, time) {
         var theta = x + time;
         var a = Math.cos(theta);
         var b = Math.sin(theta);

--- a/examples/test/history.html
+++ b/examples/test/history.html
@@ -20,23 +20,20 @@
     three.camera.position.set(3.5, 1.4, -2.3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.frames / 200
-
-      t = Math.max(three.Time.clock, 0) / 25
-      t = t < .5 ? t * t : t - .25
-
-      o = .5 - .5 * Math.cos(Math.min(1, t) * π)
-
-      c = Math.cos(t);
-      s = Math.sin(t);
-      view.set('quaternion', [0, -s, 0, c]);
-    });
-
     view = mathbox.cartesian({
       range: [[-3, 3], [-.25, .75], [-3, 3]],
       scale: [2, 1, 2],
+    },{
+      quaternion: function(time){
+        t = Math.max(time, 0) / 25
+        t = t < .5 ? t * t : t - .25
+
+        o = .5 - .5 * Math.cos(Math.min(1, t) * π)
+
+        c = Math.cos(t);
+        s = Math.sin(t);
+        return [0, -s, 0, c];
+      }
     });
 
     view.axis({
@@ -66,7 +63,8 @@
       items: 1,
       axis: 1,
       history: 96,
-      expr: function (emit, x, i) {
+      expr: function (emit, x, i, time) {
+        time /= 3;
         z = Math.sin(time * 5) * 3;
         y = .25 + Math.cos(x + z + Math.sin(1.52 * x - z * z / 3 + x * z * .25 + time) + time * 3) * .25;
         emit(x, y, z);

--- a/examples/test/join.html
+++ b/examples/test/join.html
@@ -20,11 +20,6 @@
     three.camera.position.set(2.3, 1, 2);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.now
-    });
-
     view = mathbox.cartesian({
       range: [[-6, 6], [-1, 1], [-1, 1]],
       scale: [6, 1, 1],
@@ -32,7 +27,7 @@
 
     view.interval({
       length: 16,
-      expr: function (emit, x, i) {
+      expr: function (emit, x, i, time) {
         var d = Math.sin(x + time);
 
         emit(.5);

--- a/examples/test/joinsplit.html
+++ b/examples/test/joinsplit.html
@@ -19,12 +19,6 @@
 
     three.camera.position.set(-3.5, 1.4, -2.3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
-//    three.renderer.setClearColor(new THREE.Color(0x000000), 1.0);
-
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock
-    });
 
     view = mathbox.cartesian({
       range: [[-3, 3], [0, 1], [-3, 3]],
@@ -51,7 +45,7 @@
       centeredX: true,
       centeredY: true,
       axes: [1, 3],
-      expr: function (emit, x, y, i, j) {
+      expr: function (emit, x, y, i, j, time) {
         emit(x, .5 + .5 * (Math.sin(x + time) * Math.sin(y + time)), y);
       },
       channels: 3,

--- a/examples/test/label.html
+++ b/examples/test/label.html
@@ -25,11 +25,6 @@
     three.camera.lookAt(new THREE.Vector3())
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock * .2;
-    });
-
     view = mathbox
     .unit({
       scale: null,
@@ -59,7 +54,7 @@
       zBias: -10,
       axes: [1, 3],
     });
-    
+
     view.array({
       id: 'colors',
       length: 2,
@@ -69,8 +64,8 @@
 
     view.interval({
       length: 16,
-      expr: function (emit, x, i) {
-        y = Math.sin(x + time / 4) * .7;// + (i%2)*Math.sin(x * 400000 + time * 5 + x * x * 10000)*.05;
+      expr: function (emit, x, i, time) {
+        y = Math.sin(x + (time*0.2) / 4) * .7;// + (i%2)*Math.sin(x * 400000 + time * 5 + x * x * 10000)*.05;
         emit(x, y);
       },
       channels: 2,
@@ -98,7 +93,8 @@
       width:  16,
       height: 5,
       depth:  2,
-      expr: function (emit, i, j) {
+      expr: function (emit, i, j, time) {
+        time *= 0.2;
         //emit('QxAfjldgざおぎぼアプヸ⾤⾘⿕⿒');
         emit(
           Math.floor(time * 2 + i / 8)

--- a/examples/test/label2.html
+++ b/examples/test/label2.html
@@ -25,11 +25,6 @@
     three.camera.lookAt(new THREE.Vector3())
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock
-    });
-
     view = mathbox
     .unit({
       scale: null,
@@ -57,8 +52,8 @@
 
     view.interval({
       length: 16,
-      expr: function (emit, x, i) {
-        y = Math.sin(x + time / 4) * .7;// + (i%2)*Math.sin(x * 400000 + time * 5 + x * x * 10000)*.05;
+      expr: function (emit, x, i, time) {
+        y = Math.sin(x + (time*0.2) / 4) * .7;// + (i%2)*Math.sin(x * 400000 + time * 5 + x * x * 10000)*.05;
         emit(x, y);
       },
       channels: 2,
@@ -87,7 +82,8 @@
       width:  16,
       height: 5,
       sdf: 0,
-      expr: function (emit, i, j) {
+      expr: function (emit, i, j, time) {
+        time *= 0.2;
         //emit('QxAfjldgざおぎぼアプヸ⾤⾘⿕⿒');
         emit(
           Math.floor(time / 2 + i/10)

--- a/examples/test/lerp.html
+++ b/examples/test/lerp.html
@@ -20,11 +20,6 @@
     three.camera.position.set(2.3, 1, 2);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.now
-    });
-
     view = mathbox.cartesian({
       range: [[-6, 6], [-1, 1], [-1, 1]],
       scale: [6, 1, 1],
@@ -32,14 +27,14 @@
 
     view.interval({
       length: 16, // number of red data points
-      expr: function (emit, x, i) {
+      items: 2,
+      channels: 2,
+      expr: function (emit, x, i, time) {
         var d = Math.sin((x + time) * 2)/2;
 
         emit(x, 0);
         emit(x, d);
       },
-      items: 2,
-      channels: 2,
     }).vector({
       color: 0xc02050,
       width: 16,

--- a/examples/test/point.html
+++ b/examples/test/point.html
@@ -19,14 +19,8 @@
       },
     });
     three = mathbox.three;
-    three.Time.set({speed: .5});
     three.camera.position.set(-3.5, 1.4, -2.3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
-
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock
-    });
 
     view = mathbox
     .set({
@@ -56,7 +50,7 @@
       width: 32,
       height: 32,
       axes: [1, 3],
-      expr: function (emit, x, y, i, j) {
+      expr: function (emit, x, y, i, j, time) {
         emit(x, .25 + .25 * (Math.sin(x + time) * Math.sin(y + time)), y);
       },
     });
@@ -85,7 +79,7 @@
 
     view.matrix({
       id: 'color',
-      expr: function (emit, i, j) {
+      expr: function (emit, i, j, time) {
         var r = .5 + Math.cos(time * .873) * j;
         var g = .5 + Math.sin(time) * i;
         var b = 1;

--- a/examples/test/pointsizes.html
+++ b/examples/test/pointsizes.html
@@ -19,14 +19,8 @@
       },
     });
     three = mathbox.three;
-    three.Time.set({speed: .5});
     three.camera.position.set(-3.5, 1.4, -2.3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
-
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock
-    });
 
     view = mathbox
     .set({
@@ -53,7 +47,7 @@
 
     view.matrix({
       id: 'size',
-      expr: function (emit, i, j) {
+      expr: function (emit, i, j, time) {
         var a = .5 + .5 * Math.cos(time * .873 + i) * (j % 2);
         var b = .5 + .5 * Math.sin(time + j) * (i % 2);
 
@@ -69,7 +63,7 @@
       width: 32,
       height: 32,
       axes: [1, 3],
-      expr: function (emit, x, y, i, j) {
+      expr: function (emit, x, y, i, j, time) {
         emit(x, .25 + .25 * (Math.sin(x + time) * Math.sin(y + time)), y);
       },
     });
@@ -101,7 +95,7 @@
 
     view.matrix({
       id: 'color',
-      expr: function (emit, i, j) {
+      expr: function (emit, i, j, time) {
         var r = .5 + Math.cos(time * .873) * j;
         var g = .5 + Math.sin(time) * i;
         var b = 1;

--- a/examples/test/resample.html
+++ b/examples/test/resample.html
@@ -20,17 +20,6 @@
     three.camera.position.set(.3, 1, 3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0;
-    origin = new THREE.Vector3();
-    three.on('update', function (event) {
-      time = three.Time.clock;
-      x = Math.cos(time) * 3;
-      z = Math.sin(time) * 3;
-
-      camera.set('position', [x, 0, z]);
-      camera.set('lookAt', origin);
-    });
-
     mathbox
       .set({
         scale: 720
@@ -39,7 +28,15 @@
         history: 2,
         type: 'unsignedByte',
       })
-        .camera()
+        .camera({
+          lookAt: [0, 0, 0]
+        },{
+          position: function(t){
+            x = Math.cos(t) * 3;
+            z = Math.sin(t) * 3;
+            return [x, 0, z];
+          }
+        })
         .shader({
           code:
             "vec4 getSample(vec3 xyz);\n"+

--- a/examples/test/spherical.html
+++ b/examples/test/spherical.html
@@ -20,25 +20,18 @@
     three.camera.position.set(.8, 1, 1.3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-
-    three.on('update', function () {
-      time = (three.Time.clock + 3) / 7;
-
-      t = Math.max(three.Time.clock - 3, 0) / 25
-      t = t < .5 ? t * t : t - .25
-
-      o = .5 - .5 * Math.cos(Math.min(1, t) * π)
-
-      c = Math.cos(t);
-      s = Math.sin(t);
-      view.set('quaternion', [0, -s, 0, c]);
-    });
-
     view = mathbox.spherical({
       bend: 1,
       range: [[-π, π], [-π/2, π/2], [0, 2]],
       scale: [2, 1, 1],
+    },{
+      quaternion: function(t){
+        t = Math.max(t - 3, 0) / 25
+        t = t < .5 ? t * t : t - .25
+        c = Math.cos(t);
+        s = Math.sin(t);
+        return [0, -s, 0, c];
+      }
     });
 
     view.area({
@@ -46,8 +39,8 @@
       height: 16,
       axes: [1, 2],
       items: 2,
-      expr: function (emit, x, y, i, j) {
-
+      expr: function (emit, x, y, i, j, time) {
+        time = (time + 3)/7;
         t = time - 10;
 
         var a = (Math.sin(x * 31.718 - t) * Math.sin(y * 21.131 + time));
@@ -78,8 +71,8 @@
       height: 16,
       axes: [1, 2],
       items: 2,
-      expr: function (emit, x, y, i, j) {
-
+      expr: function (emit, x, y, i, j, time) {
+        time = (time + 3)/7;
         t = time + 10;
 
         var a = (Math.sin(x * 31.718 - t) * Math.sin(y * 21.131 + time));

--- a/examples/test/split.html
+++ b/examples/test/split.html
@@ -20,11 +20,6 @@
     three.camera.position.set(2.3, 1, 2);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.now
-    });
-
     view = mathbox.cartesian({
       range: [[-6, 6], [-1, 1], [-1, 1]],
       scale: [6, 1, 1],
@@ -32,7 +27,7 @@
 
     view.interval({
       length: 16,
-      expr: function (emit, x, i) {
+      expr: function (emit, x, i, time) {
         var d = Math.sin(x + time);
 
         emit(.5);

--- a/examples/test/stereographic.html
+++ b/examples/test/stereographic.html
@@ -20,22 +20,6 @@
     three.camera.position.set(0, 0, 10);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    q1 = new THREE.Quaternion();
-    q2 = new THREE.Quaternion();
-    three.on('update', function () {
-      time = three.Time.now
-
-      q1.x = Math.cos(time * .123);
-      q1.y = Math.cos(time * .224 - 1);
-      q1.z = Math.cos(time * .161 + 1);
-      q1.w = Math.cos(time * .193 + 2);
-      q1.normalize();
-
-      q2.slerp(q1, .05);
-      spherical.set('quaternion', q2);
-    });
-
     stereo = mathbox.set({
       focus: 10
     }).stereographic({
@@ -43,8 +27,21 @@
       bend: 1,
     });
 
+    q1 = new THREE.Quaternion();
+    q2 = new THREE.Quaternion();
     spherical = stereo.spherical({
       range: [[-π, π], [-π/2, π/2], [-1, 1]],
+    },{
+      quaternion: function(t){
+        q1.x = Math.cos(t * .123);
+        q1.y = Math.cos(t * .224 - 1);
+        q1.z = Math.cos(t * .161 + 1);
+        q1.w = Math.cos(t * .193 + 2);
+        q1.normalize();
+
+        q2.slerp(q1, .05);
+        return q2;
+      }
     });
 
     spherical

--- a/examples/test/surface.html
+++ b/examples/test/surface.html
@@ -19,12 +19,6 @@
 
     three.camera.position.set(-3.5, 2.2, -3.3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
-//    three.renderer.setClearColor(new THREE.Color(0x000000), 1.0);
-
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock
-    });
 
     view = mathbox.cartesian({
       range: [[-3, 3], [0, 1], [-3, 3]],
@@ -49,7 +43,7 @@
       width: 64,
       height: 64,
       axes: [1, 3],
-      expr: function (emit, x, y, i, j) {
+      expr: function (emit, x, y, i, j, time) {
         emit(x, .35 + .25 * (Math.sin(x + time) * Math.sin(y + time)), y);
         emit(x, .35 + .25 * (Math.sin(x * 1.31 + time * 1.13) * Math.sin(y * 1.46 - time * .94)) + .5, y);
         emit(x, .35 + .25 * (Math.sin(x * 1.25 + Math.sin(y + time) - time * 1.34) * Math.sin(y * 1.17 - time * .79)) + 1, y);
@@ -60,7 +54,7 @@
 
     var color = view.matrix({
       id: 'color',
-      expr: function (emit, i, j) {
+      expr: function (emit, i, j, time) {
         var r = .5 + Math.cos(time * .873) * j;
         var g = .5 + Math.sin(time) * i;
         var b = 1;

--- a/examples/test/transition.html
+++ b/examples/test/transition.html
@@ -19,7 +19,6 @@
 
     three.camera.position.set(-3.5, 2.2, -3.3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
-//    three.renderer.setClearColor(new THREE.Color(0x000000), 1.0);
 
     function pingpong(t) {
       return Math.sin(t)
@@ -30,10 +29,10 @@
       time = three.Time.clock;
       var enter = Math.min(1,  1 + pingpong(time));
       var exit  = Math.min(1,  1 - pingpong(time));
-      
+
       enter = 1.0 - Math.pow(1.0 - enter, 2);
       exit  = 1.0 - Math.pow(1.0 - exit,  2);
-      
+
       move.set({ enter: enter, exit: exit })
       reveal.set({ enter: enter, exit: exit })
     });

--- a/examples/test/visible.html
+++ b/examples/test/visible.html
@@ -20,11 +20,6 @@
     three.camera.position.set(0, 0, 3);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.clock
-    });
-
     mathbox
     .set({
       focus: 3,

--- a/examples/test/world.html
+++ b/examples/test/world.html
@@ -17,12 +17,6 @@
     });
     three = mathbox.three;
 
-    three.on('update', function () {
-      var t = three.Time.now
-
-      view.set('quaternion', [0, Math.cos(t), 0, Math.sin(t)]);
-    });
-
     three.camera.position.set(0, 1, 4);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
@@ -30,6 +24,10 @@
       range: [[-1, 1], [-1, 1], [-1, 1]],
       scale: [.5, .5, .5],
       quaternion: [.866, 0, 0, -.5]
+    },{
+      quaternion: function(t){
+        return [0, Math.cos(t), 0, Math.sin(t)]
+      }
     });
 
     view.transform({

--- a/examples/test/xyzw.html
+++ b/examples/test/xyzw.html
@@ -44,9 +44,6 @@
     view.line({
       color: 0x3090FF,
       width: 10,
-      size: 0.1,
-      start: true,
-      end: true,
     });
 
   </script>

--- a/examples/test/xyzw.html
+++ b/examples/test/xyzw.html
@@ -20,11 +20,6 @@
     three.camera.position.set(2.3, 1, 2);
     three.renderer.setClearColor(new THREE.Color(0xFFFFFF), 1.0);
 
-    time = 0
-    three.on('update', function () {
-      time = three.Time.now
-    });
-
     view = mathbox.cartesian({
       range: [[-6, 6], [-1, 1], [-1, 1]],
       scale: [6, 1, 1],
@@ -32,7 +27,7 @@
 
     view.interval({
       length: 128,
-      expr: function (emit, x, i) {
+      expr: function (emit, x, i, time) {
         var d = Math.sin((x + time) * 2);
 
         emit(x, 0);


### PR DESCRIPTION
As asked for on the mailing list, this removes most uses of `three.on("update"` from `examples/test`. Those that are left are non-trivial and are probably fine as they are.

I also removed invisible arrows from another example, and added my own Color Cube example. I was surprised at how well it came out and how simple the code is.