### PR TITLE
fix texture flip_y bug

### DIFF
--- a/src/primitives/types/operator/lerp.coffee
+++ b/src/primitives/types/operator/lerp.coffee
@@ -106,7 +106,7 @@ class Lerp extends Operator
     any = false
     for key, i in ['width', 'height', 'depth', 'items']
       centered = @centered[key]
-      any || = centered
+      any ||= centered
       vec[i] = if centered then "0.5" else "0.0"
 
     # Add centered sampling offset (from source)

--- a/src/primitives/types/operator/resample.coffee
+++ b/src/primitives/types/operator/resample.coffee
@@ -127,7 +127,7 @@ class Resample extends Operator
     any = false
     for key, i in ['width', 'height', 'depth', 'items']
       centered = @centered[key]
-      any || = centered
+      any ||= centered
       vec[i] = if centered then "0.5" else "0.0"
 
     if any

--- a/src/render/buffer/texture/datatexture.coffee
+++ b/src/render/buffer/texture/datatexture.coffee
@@ -73,6 +73,8 @@ class DataTexture
     # Write to rectangle
     gl.bindTexture gl.TEXTURE_2D, @texture
     gl.pixelStorei gl.UNPACK_ALIGNMENT, 1
+    gl.pixelStorei gl.UNPACK_FLIP_Y_WEBGL, false
+    gl.pixelStorei gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false
     gl.texSubImage2D gl.TEXTURE_2D, 0, x, y, w, h, @format, @type, data
 
   dispose: () ->


### PR DESCRIPTION
Loading any texture with TextureLoader caused 'area' and 'matrix' sources to flip y axis due to UNPACK_FLIP_Y_WEBGL set to true by Three.JS.