### PR TITLE
do not call inspect if mathbox was destroyed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,7 @@ Bootstrap.registerPlugin("mathbox", {
       three.MathBox.init();
 
       return setTimeout(() => {
-        if (this.options.inspect) {
+        if (this.options.inspect && three.MathBox) {
           return this.inspect(three);
         }
       });

--- a/test/mathBox.spec.ts
+++ b/test/mathBox.spec.ts
@@ -1,0 +1,23 @@
+import * as MathBox from "../src";
+import { smallPause } from "./test_utils";
+
+describe("mathBox", () => {
+  describe("ready", () => {
+    it("it calls inspect asynchronously", async () => {
+      const mathbox = MathBox.mathBox();
+      const inspect = spyOn(mathbox, "inspect");
+      expect(inspect).toHaveBeenCalledTimes(0);
+      await smallPause();
+      expect(inspect).toHaveBeenCalledTimes(1);
+    });
+
+    it("it does not call inspect if mathbox was destroyed", async () => {
+      const mathbox = MathBox.mathBox();
+      const inspect = spyOn(mathbox, "inspect");
+      mathbox.three.destroy();
+      expect(inspect).toHaveBeenCalledTimes(0);
+      await smallPause();
+      expect(inspect).toHaveBeenCalledTimes(0);
+    });
+  });
+});


### PR DESCRIPTION
Mathbox throws an unimportant but mildly annoying error if you destroy it immediately after creating it:

```
const mathbox = mathBox();
mathbox.destroy()
```

You'll see an error logged in the console. (It's thrown asynchronously from a setTimeout, so doesn't really mess anything up).

Anyway, this fixes the issue. 