### PR TITLE
Cc/fix dark surfaces

### DIFF
--- a/src/shaders/glsl/mesh.fragment.shaded.js
+++ b/src/shaders/glsl/mesh.fragment.shaded.js
@@ -1,4 +1,6 @@
-export default /* glsl */ `varying vec3 vNormal;
+export default /* glsl */ `
+#extension GL_OES_standard_derivatives : enable
+varying vec3 vNormal;
 varying vec3 vLight;
 varying vec3 vPosition;
 
@@ -16,7 +18,12 @@ vec4 getShadedColor(vec4 rgba) {
   vec3 light = normalize(vLight);
   vec3 position = normalize(vPosition);
   
-  float side    = gl_FrontFacing ? -1.0 : 1.0;
+  // Workaround to avoid gl_FrontFacing. See https://github.com/unconed/mathbox/pull/26
+  vec3 pdx = dFdx(vPosition);
+  vec3 pdy = dFdy(vPosition);
+  bool frontFacting = dot(vNormal, cross(pdx, pdy)) > 0.0;
+
+  float side = frontFacting ? 1.0 : -1.0;
   float cosine  = side * dot(normal, light);
   float diffuse = mix(max(0.0, cosine), .5 + .5 * cosine, .1);
   


### PR DESCRIPTION
### What are the relevant tickets? #25 
_Note that #25 mentions two issues: dark surfaces and black gridlines. This addresses the dark surfaces, NOT the gridlines. I believe I understand how to fix that, too, but want to write some js tests for it._

### What does this PR do?
This PR replaces existing usage of `gl_FrontFacing` with a cross-product workaround; `gl_FrontFacing` seems not to be behaving how mathbox expected.

### How should this be manually tested
1. On this branch, `npm run build`
2. Open `examples/test/surface.html`. Change the mathbox line to `<script type="text/javascript" src="../../build/bundle/mathbox.js"></script>` to use local build
3. Optionally, comment out the `lineX` and `lineY` bits at end of `surface.html`. The affect is more proncounced without the gridlines

**Master** / **This branch**
<img width="300" alt="Screen Shot 2022-04-10 at 10 40 46 PM" src="https://user-images.githubusercontent.com/9010790/162656742-25fd8dae-9105-4cd3-b24b-dc35bfe5a751.png"> / <img width="300" alt="Screen Shot 2022-04-10 at 10 40 17 PM" src="https://user-images.githubusercontent.com/9010790/162656749-1f70b8d9-92bf-4ef8-ad32-1533140c117d.png">

