### PR TITLE
fix gridlines on filled surfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mathbox",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mathbox",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "css-select": "^4.2.1",
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@types/jasmine": "^3.10.3",
+        "@types/three": "^0.139.0",
         "@typescript-eslint/eslint-plugin": "^5.14.0",
         "@typescript-eslint/parser": "^5.14.0",
         "concurrently": "^7.0.0",
@@ -28,6 +29,7 @@
         "karma-chrome-launcher": "^3.1.0",
         "karma-jasmine": "^4.0.1",
         "prettier": "2.3.1",
+        "three": "^0.139.2",
         "ts-loader": "^9.2.8",
         "typedoc": "^0.22.13",
         "typescript": "^4.6.2",
@@ -302,6 +304,12 @@
       "version": "17.0.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
       "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
+      "dev": true
+    },
+    "node_modules/@types/three": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.139.0.tgz",
+      "integrity": "sha512-4V/jZhyq7Mv05coUzxL3bz8AuBOSi/1F0RY7ujisHTV0Amy/fnYJ+s7TSJ1/hXjZukSkpuFRgV+wvWUEMbsMbQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7983,10 +7991,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.137.5",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.137.5.tgz",
-      "integrity": "sha512-rTyr+HDFxjnN8+N/guZjDgfVxgHptZQpf6xfL/Mo7a5JYIFwK6tAq3bzxYYB4Ae0RosDZlDuP+X5aXDXz+XnHQ==",
-      "peer": true
+      "version": "0.139.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
+      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
     },
     "node_modules/threestrap": {
       "version": "0.4.1",
@@ -9364,6 +9371,12 @@
       "version": "17.0.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
       "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
+      "dev": true
+    },
+    "@types/three": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.139.0.tgz",
+      "integrity": "sha512-4V/jZhyq7Mv05coUzxL3bz8AuBOSi/1F0RY7ujisHTV0Amy/fnYJ+s7TSJ1/hXjZukSkpuFRgV+wvWUEMbsMbQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -15346,10 +15359,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.137.5",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.137.5.tgz",
-      "integrity": "sha512-rTyr+HDFxjnN8+N/guZjDgfVxgHptZQpf6xfL/Mo7a5JYIFwK6tAq3bzxYYB4Ae0RosDZlDuP+X5aXDXz+XnHQ==",
-      "peer": true
+      "version": "0.139.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
+      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
     },
     "threestrap": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@types/jasmine": "^3.10.3",
+    "@types/three": "^0.139.0",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
     "concurrently": "^7.0.0",
@@ -60,6 +61,7 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-jasmine": "^4.0.1",
     "prettier": "2.3.1",
+    "three": "^0.139.2",
     "ts-loader": "^9.2.8",
     "typedoc": "^0.22.13",
     "typescript": "^4.6.2",

--- a/src/primitives/types/draw/surface.js
+++ b/src/primitives/types/draw/surface.js
@@ -277,13 +277,13 @@ export class Surface extends Primitive {
       this.wireColor.copy(color);
       if (fill) {
         const c = this.wireScratch;
-        c.setRGB(color.x, color.y, color.z);
+        c.setRGB(color.r, color.g, color.b);
         this._convertLinearToGamma(
           this._convertGammaToLinear(c).multiplyScalar(0.75)
         );
-        this.wireColor.x = c.r;
-        this.wireColor.y = c.g;
-        this.wireColor.z = c.b;
+        this.wireColor.r = c.r;
+        this.wireColor.g = c.g;
+        this.wireColor.b = c.b;
       }
     }
 

--- a/test/primitives/types/data/surface.spec.ts
+++ b/test/primitives/types/data/surface.spec.ts
@@ -1,0 +1,77 @@
+import * as MB from "../../../../src";
+import { Color } from "three/src/math/Color.js";
+import { smallPause } from "../../../test_utils";
+
+describe("surface", () => {
+  describe("lineX and lineY", () => {
+    const setup = (props: MB.SurfaceProps = {}) => {
+      const mathbox = MB.mathBox();
+      const cartesian = mathbox.cartesian();
+      const area = cartesian.area({
+        expr: (emit, x, y) => emit(x, x * y, y),
+        items: 1,
+        channels: 3,
+      });
+      const surface = cartesian.surface({
+        points: area,
+        ...props,
+      });
+      return { surface, mathbox };
+    };
+
+    it("only renders gridlines if lineX, lineY are true", async () => {
+      const { surface } = setup();
+
+      const controller = surface[0].controller;
+
+      expect(controller.lineX).toBe(null);
+      expect(controller.lineY).toBe(null);
+
+      surface.set({ lineX: true });
+      await smallPause();
+
+      expect(controller.lineX).not.toBe(null);
+      expect(controller.lineY).toBe(null);
+
+      surface.set({ lineY: true });
+      await smallPause();
+
+      expect(controller.lineX).not.toBe(null);
+      expect(controller.lineY).not.toBe(null);
+    });
+
+    it("darkens the gridlines iff surface is filled", async () => {
+      const { surface } = setup({
+        color: new Color(0.4, 0.6, 0.8).getHex(),
+        fill: false,
+        lineX: true,
+        lineY: true,
+      });
+      const controller = surface[0].controller;
+
+      const unfilledX = controller.lineX.uniforms.styleColor;
+      const unfilledY = controller.lineY.uniforms.styleColor;
+      expect(unfilledX.value).toEqual(new Color(0.4, 0.6, 0.8));
+      expect(unfilledY.value).toEqual(new Color(0.4, 0.6, 0.8));
+
+      surface.set({ fill: true });
+      await smallPause();
+
+      const filledX = controller.lineX.uniforms.styleColor;
+      const filledY = controller.lineY.uniforms.styleColor;
+
+      /**
+       * Mostly asserting here that these values are lower (darker) than the
+       * original 0.4, 0.6, 0.8
+       */
+
+      expect(filledX.value.r).toBeCloseTo(0.35, 2);
+      expect(filledX.value.g).toBeCloseTo(0.52, 2);
+      expect(filledX.value.b).toBeCloseTo(0.69, 2);
+
+      expect(filledY.value.r).toBeCloseTo(0.35, 2);
+      expect(filledY.value.g).toBeCloseTo(0.52, 2);
+      expect(filledY.value.b).toBeCloseTo(0.69, 2);
+    });
+  });
+});


### PR DESCRIPTION
### Is there a related issue? #25 
_#25 is mostly about shaded surfaces being too dark, but we also noticed a gridline issue there, too._

### What does this PR do?
In #25 we noted that recent versions of mathbox (including znah's ThreeJS r84 fork) have black gridlines. This fixes that issue. 

**v0.0.5** Gridlines exactly same color as surface, so not visible unless surface is shaded. _From the code in 0.0.5 it's clear the intent was to darken the gridlines, but this appears not to have been working in 0.0.5_
<img width="1585" alt="Screen Shot 2022-04-13 at 6 23 40 PM" src="https://user-images.githubusercontent.com/9010790/163281427-dc7cb664-9be8-4273-8234-db5341ae4c77.png">

**v2.1.3** Black gridlines in all cases. Also darker shaded surface; see #26 
<img width="1517" alt="Screen Shot 2022-04-13 at 6 20 38 PM" src="https://user-images.githubusercontent.com/9010790/163281436-62d65a9a-dd71-48c9-a4d3-b80447760a3b.png">

**This branch** Gridlines of proper color; darker surface will be fixed by #26 
<img width="1669" alt="Screen Shot 2022-04-13 at 6 17 41 PM" src="https://user-images.githubusercontent.com/9010790/163281454-94874877-9cf8-404a-b96b-faa9d8d6a0be.png">

