### PR TITLE
add new types for latch, reveal, etc

### DIFF
--- a/src/node_types.ts
+++ b/src/node_types.ts
@@ -55,6 +55,24 @@ interface SetTraitsObject {
   visible?: Parameters<Traits["object"]["visible"]["validate"]>[0];
 }
 
+interface GetTraitsLatch {
+  data: ReturnType<Traits["latch"]["data"]["validate"]>;
+  deep: ReturnType<Traits["latch"]["deep"]["validate"]>;
+}
+
+interface SetTraitsLatch {
+  /**
+   * Data to monitor for changes
+   * @default `null`
+   */
+  data?: Parameters<Traits["latch"]["data"]["validate"]>[0];
+  /**
+   * Do deep value comparison
+   * @default `true`
+   */
+  deep?: Parameters<Traits["latch"]["deep"]["validate"]>[0];
+}
+
 interface GetTraitsUnit {
   scale: ReturnType<Traits["unit"]["scale"]["validate"]>;
   fov: ReturnType<Traits["unit"]["fov"]["validate"]>;
@@ -1000,6 +1018,7 @@ interface GetTraitsMesh {
   fill: ReturnType<Traits["mesh"]["fill"]["validate"]>;
   shaded: ReturnType<Traits["mesh"]["shaded"]["validate"]>;
   map: ReturnType<Traits["mesh"]["map"]["validate"]>;
+  normals: ReturnType<Traits["mesh"]["normals"]["validate"]>;
   lineBias: ReturnType<Traits["mesh"]["lineBias"]["validate"]>;
 }
 
@@ -1022,7 +1041,12 @@ interface SetTraitsMesh {
    * @example `"#map"`
    */
   map?: Parameters<Traits["mesh"]["map"]["validate"]>[0];
-
+  /**
+   * Normals data source
+   * @default `null`
+   * @example `"#normals"`
+   */
+  normals?: Parameters<Traits["mesh"]["normals"]["validate"]>[0];
   /**
    * Z-Bias for lines on fill
    * @default `5`
@@ -1367,6 +1391,8 @@ interface SetTraitsTexture {
 interface GetTraitsShader {
   sources: ReturnType<Traits["shader"]["sources"]["validate"]>;
   language: ReturnType<Traits["shader"]["language"]["validate"]>;
+  indices: ReturnType<Traits["shader"]["indices"]["validate"]>;
+  channels: ReturnType<Traits["shader"]["channels"]["validate"]>;
   code: ReturnType<Traits["shader"]["code"]["validate"]>;
   uniforms: ReturnType<Traits["shader"]["uniforms"]["validate"]>;
 }
@@ -1390,6 +1416,18 @@ interface SetTraitsShader {
    * @default `""`
    */
   code?: Parameters<Traits["shader"]["code"]["validate"]>[0];
+
+  /**
+   * Source indices
+   * @default `4`
+   */
+  indices?: Parameters<Traits["shader"]["indices"]["validate"]>[0];
+
+  /**
+   * Source channels
+   * @default `4`
+   */
+  channels?: Parameters<Traits["shader"]["channels"]["validate"]>[0];
 
   /**
    * Shader uniform objects (three.js style)
@@ -1692,6 +1730,36 @@ interface SetTraitsSlice {
    * @example `[2, 4]`
    */
   depth?: Parameters<Traits["slice"]["depth"]["validate"]>[0];
+}
+
+interface GetTraitsReverse {
+  items: ReturnType<Traits["reverse"]["items"]["validate"]>;
+  width: ReturnType<Traits["reverse"]["width"]["validate"]>;
+  height: ReturnType<Traits["reverse"]["height"]["validate"]>;
+  depth: ReturnType<Traits["reverse"]["depth"]["validate"]>;
+}
+
+interface SetTraitsReverse {
+  /**
+   * Reverse items
+   * @default `false`
+   */
+  items?: Parameters<Traits["reverse"]["items"]["validate"]>[0];
+  /**
+   * Reverse width
+   * @default `false`
+   */
+  width?: Parameters<Traits["reverse"]["width"]["validate"]>[0];
+  /**
+   * Reverse height
+   * @default `false`
+   */
+  height?: Parameters<Traits["reverse"]["height"]["validate"]>[0];
+  /**
+   * Reverse depth
+   * @default `false`
+   */
+  depth?: Parameters<Traits["reverse"]["depth"]["validate"]>[0];
 }
 
 interface GetTraitsLerp {
@@ -2832,6 +2900,24 @@ export interface LabelProps
     SetTraitsGeometry {}
 
 /**
+ * Normalized properties for {@link MathboxSelection.latch | latch}.
+ * @category data
+ */
+export interface LatchPropsNormalized
+  extends GetTraitsNode,
+    GetTraitsLatch,
+    GetTraitsEntity {}
+
+/**
+ * Properties for {@link MathboxSelection.latch | latch}.
+ * @category data
+ */
+export interface LatchProps
+  extends SetTraitsNode,
+    SetTraitsLatch,
+    SetTraitsEntity {}
+
+/**
  * Normalized properties for {@link MathboxSelection.layer | layer}.
  * @category transform
  */
@@ -3150,6 +3236,24 @@ export interface RevealPropsNormalized
  * @category present
  */
 export interface RevealProps extends SetTraitsNode, SetTraitsTransition {}
+
+/**
+ * Normalized properties for {@link MathboxSelection.reverse | reverse}.
+ * @category operator
+ */
+export interface ReversePropsNormalized
+  extends GetTraitsNode,
+    GetTraitsOperator,
+    GetTraitsReverse {}
+
+/**
+ * Properties for {@link MathboxSelection.reverse | reverse}.
+ * @category operator
+ */
+export interface ReverseProps
+  extends SetTraitsNode,
+    SetTraitsOperator,
+    SetTraitsReverse {}
 
 /**
  * Normalized properties for {@link MathboxSelection.root | root}.

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,10 @@ import type {
   VolumeEmitter,
   VoxelEmitter,
 } from "./primitives/types/types_typed";
+import { Classes } from "./primitives/types/classes";
+
+export type NodeType = keyof typeof Classes;
+
 export * from "./node_types";
 
 export {
@@ -54,6 +58,7 @@ export type Props = {
   interval: TT.IntervalProps;
   join: TT.JoinProps;
   label: TT.LabelProps;
+  latch: TT.LatchProps;
   layer: TT.LayerProps;
   lerp: TT.LerpProps;
   line: TT.LineProps;
@@ -71,6 +76,7 @@ export type Props = {
   resample: TT.ResampleProps;
   retext: TT.RetextProps;
   reveal: TT.RevealProps;
+  reverse: TT.ReverseProps;
   root: TT.RootProps;
   rtt: TT.RttProps;
   scale: TT.ScaleProps;
@@ -122,6 +128,7 @@ export type PropsNoramlized = {
   interval: TT.IntervalPropsNormalized;
   join: TT.JoinPropsNormalized;
   label: TT.LabelPropsNormalized;
+  latch: TT.LatchPropsNormalized;
   layer: TT.LayerPropsNormalized;
   lerp: TT.LerpPropsNormalized;
   line: TT.LinePropsNormalized;
@@ -139,6 +146,7 @@ export type PropsNoramlized = {
   resample: TT.ResamplePropsNormalized;
   retext: TT.RetextPropsNormalized;
   reveal: TT.RevealPropsNormalized;
+  reverse: TT.ReversePropsNormalized;
   root: TT.RootPropsNormalized;
   rtt: TT.RttPropsNormalized;
   scale: TT.ScalePropsNormalized;
@@ -167,8 +175,6 @@ export type PropsNoramlized = {
   volume: TT.VolumePropsNormalized;
   voxel: TT.VoxelPropsNormalized;
 };
-
-export type NodeType = keyof Props;
 
 /**
  * MathBox (virtual)-DOM Nodes.
@@ -441,6 +447,14 @@ export interface MathboxSelection<Type extends NodeType = NodeType> {
    */
   label(props?: TT.LabelProps): MathboxSelection<"label">;
   /**
+   * Create new `latch` node.
+   *
+   * See also {@link LatchProps} and {@link LatchPropsNormalized}.
+   *
+   * @category data
+   */
+  latch(props?: TT.LatchProps): MathboxSelection<"latch">;
+  /**
    * Create new `layer` node.
    *
    * See also {@link LayerProps} and {@link LayerPropsNormalized}.
@@ -576,6 +590,14 @@ export interface MathboxSelection<Type extends NodeType = NodeType> {
    * @category present
    */
   reveal(props?: TT.RevealProps): MathboxSelection<"reveal">;
+  /**
+   * Create new `reveal` node.
+   *
+   * See also {@link ReverseProps} and {@link ReversePropsNormalized}.
+   *
+   * @category operator
+   */
+  reverse(props?: TT.ReverseProps): MathboxSelection<"reverse">;
   /**
    * Create new `root` node.
    *


### PR DESCRIPTION
This is a followup to https://github.com/unconed/mathbox/pull/32, adding typescript definitions for those changes