### PR TITLE
set willReadFrequently to true in textatlas.js

### DIFF
--- a/src/render/buffer/textatlas.js
+++ b/src/render/buffer/textatlas.js
@@ -76,7 +76,7 @@ export class TextAtlas extends Atlas {
     const quote = (str) => `${str.replace(/(['"\\])/g, "\\$1")}`;
     const font = this.font.map(quote).join(", ");
 
-    const context = canvas.getContext("2d");
+    const context = canvas.getContext("2d", { willReadFrequently: true });
     context.font = `${this.style} ${this.variant} ${this.weight} ${this.size}px ${font}`;
     context.fillStyle = "#FF0000";
     context.textAlign = "left";


### PR DESCRIPTION
This change fixes these warnings when I include text on my axes:

<img width="790" alt="image" src="https://user-images.githubusercontent.com/69635/203608405-1ec0881e-b2ad-479b-83d0-42139fc70c00.png">