### PR TITLE
fix mathbox.debug()

### DIFF
--- a/src/stage/api.js
+++ b/src/stage/api.js
@@ -214,8 +214,7 @@ export class API {
     console.log("Renders: ", info.renders);
     console.log("Shaders: ", info.shaders);
 
-    const getName = (owner) =>
-      owner.constructor.toString().match("function +([^(]*)")[1];
+    const getName = (owner) => owner.constructor.name;
 
     const shaders = [];
     for (const shader of Array.from(info.shaders)) {


### PR DESCRIPTION
This closes #36 .

This bug occurred because https://github.com/unconed/mathbox/blob/master/src/stage/api.js#L217-L218 was attempting to match the name of code compiled to `function Arrow(...) {...}` style, instead of the new es6 style that our webpack build produces.

Lucky for us, the fix is cleaner than the old way, and works with both minified and non-minified code.

with `mathbox.js` on `curve.html:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/69635/204163385-db1fb5e3-29c6-414d-a0a1-165510c38ba3.png">

And with `mathbox.min.js`:

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/69635/204163365-86b6840d-1ff3-4a31-a5e0-8b72528892c8.png">

The only difference is the capitalization of the class, and I don't think that's worth worrying about given that the old code before our changes wouldn't work at all with minified code. For example, see `e - Vertex`:

https://acko.net/files/mathbox2/iframe-quat.html

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/69635/204163413-df656b96-746a-4e7e-9314-c9ba71de737f.png">

