### PR TITLE
add types for suffixed properties, paddingX, etc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "mathbox",
-  "version": "2.1.4",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.4",
+      "name": "mathbox",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "css-select": "^4.2.1",
@@ -30,7 +31,7 @@
         "prettier": "2.3.1",
         "three": "^0.139.2",
         "ts-loader": "^9.2.8",
-        "typedoc": "^0.22.13",
+        "typedoc": "^0.23.23",
         "typescript": "^4.6.2",
         "webpack": "^5.38.1",
         "webpack-cli": "^4.9.2"
@@ -4291,9 +4292,9 @@
       "dev": true
     },
     "node_modules/jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "node_modules/jsonfile": {
@@ -4826,9 +4827,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -6523,14 +6524,14 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
       "dev": true,
       "dependencies": {
         "jsonc-parser": "^3.0.0",
         "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
+        "vscode-textmate": "^6.0.0"
       }
     },
     "node_modules/signal-exit": {
@@ -7627,25 +7628,24 @@
       "dev": true
     },
     "node_modules/typedoc": {
-      "version": "0.22.13",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
-      "integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
+      "version": "0.23.23",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
+      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.12",
-        "minimatch": "^5.0.1",
-        "shiki": "^0.10.1"
+        "marked": "^4.2.4",
+        "minimatch": "^5.1.1",
+        "shiki": "^0.11.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -7658,9 +7658,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -8018,15 +8018,15 @@
       }
     },
     "node_modules/vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "node_modules/watchpack": {
@@ -11788,9 +11788,9 @@
       "dev": true
     },
     "jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "jsonfile": {
@@ -12203,9 +12203,9 @@
       }
     },
     "marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
       "dev": true
     },
     "matchdep": {
@@ -13488,14 +13488,14 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.0.0",
         "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
+        "vscode-textmate": "^6.0.0"
       }
     },
     "signal-exit": {
@@ -14358,16 +14358,15 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.22.13",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
-      "integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
+      "version": "0.23.23",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
+      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
       "dev": true,
       "requires": {
-        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.12",
-        "minimatch": "^5.0.1",
-        "shiki": "^0.10.1"
+        "marked": "^4.2.4",
+        "minimatch": "^5.1.1",
+        "shiki": "^0.11.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -14380,9 +14379,9 @@
           }
         },
         "minimatch": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -14662,15 +14661,15 @@
       "dev": true
     },
     "vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prettier": "2.3.1",
     "three": "^0.139.2",
     "ts-loader": "^9.2.8",
-    "typedoc": "^0.22.13",
+    "typedoc": "^0.23.23",
     "typescript": "^4.6.2",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.9.2"

--- a/src/node_types.ts
+++ b/src/node_types.ts
@@ -10,6 +10,14 @@ import { Traits as TraitsValue } from "./primitives/types/traits";
 
 type Traits = typeof TraitsValue;
 
+/**
+ * Create a type with the same keys as `R` but with the suffix `S` appended.
+ * Keys of `R` that are not strings are ignored.
+ */
+type Suffixed<R, S extends string> = {
+  [K in keyof R as K extends string ? `${K}${S}` : never]: R[K];
+};
+
 interface GetTraitsNode {
   id: ReturnType<Traits["node"]["id"]["validate"]>;
   classes: ReturnType<Traits["node"]["classes"]["validate"]>;
@@ -2459,7 +2467,11 @@ export interface AreaPropsNormalized
     GetTraitsData,
     GetTraitsMatrix,
     GetTraitsTexture,
-    GetTraitsArea {
+    GetTraitsArea,
+    Suffixed<GetTraitsSpan, "X">,
+    Suffixed<GetTraitsSpan, "Y">,
+    Suffixed<GetTraitsSampler, "X">,
+    Suffixed<GetTraitsSampler, "Y"> {
   expr: AreaEmitter | null;
 }
 
@@ -2473,7 +2485,11 @@ export interface AreaProps
     SetTraitsData,
     SetTraitsMatrix,
     SetTraitsTexture,
-    SetTraitsArea {
+    SetTraitsArea,
+    Suffixed<SetTraitsSpan, "X">,
+    Suffixed<SetTraitsSpan, "Y">,
+    Suffixed<SetTraitsSampler, "X">,
+    Suffixed<SetTraitsSampler, "Y"> {
   expr?: AreaEmitter;
 }
 
@@ -2742,7 +2758,13 @@ export interface GridPropsNormalized
     GetTraitsLine,
     GetTraitsGrid,
     GetTraitsArea,
-    GetTraitsOrigin {}
+    GetTraitsOrigin,
+    Suffixed<GetTraitsAxis, "X">,
+    Suffixed<GetTraitsAxis, "Y">,
+    Suffixed<GetTraitsScale, "X">,
+    Suffixed<GetTraitsScale, "Y">,
+    Suffixed<GetTraitsSpan, "X">,
+    Suffixed<GetTraitsSpan, "Y"> {}
 
 /**
  * Properties for {@link MathboxSelection.grid | grid}.
@@ -2755,7 +2777,13 @@ export interface GridProps
     SetTraitsLine,
     SetTraitsGrid,
     SetTraitsArea,
-    SetTraitsOrigin {}
+    SetTraitsOrigin,
+    Suffixed<SetTraitsAxis, "X">,
+    Suffixed<SetTraitsAxis, "Y">,
+    Suffixed<SetTraitsScale, "X">,
+    Suffixed<SetTraitsScale, "Y">,
+    Suffixed<SetTraitsSpan, "X">,
+    Suffixed<SetTraitsSpan, "Y"> {}
 
 /**
  * Normalized properties for {@link MathboxSelection.group | group}.
@@ -2942,7 +2970,11 @@ export interface LayerProps
 export interface LerpPropsNormalized
   extends GetTraitsNode,
     GetTraitsOperator,
-    GetTraitsLerp {}
+    GetTraitsLerp,
+    Suffixed<GetTraitsSampler, "X">,
+    Suffixed<GetTraitsSampler, "Y">,
+    Suffixed<GetTraitsSampler, "Z">,
+    Suffixed<GetTraitsSampler, "W"> {}
 
 /**
  * Properties for {@link MathboxSelection.lerp | lerp}.
@@ -2951,7 +2983,11 @@ export interface LerpPropsNormalized
 export interface LerpProps
   extends SetTraitsNode,
     SetTraitsOperator,
-    SetTraitsLerp {}
+    SetTraitsLerp,
+    Suffixed<SetTraitsSampler, "X">,
+    Suffixed<SetTraitsSampler, "Y">,
+    Suffixed<SetTraitsSampler, "Z">,
+    Suffixed<SetTraitsSampler, "W"> {}
 
 /**
  * Normalized properties for {@link MathboxSelection.line | line}.
@@ -3191,7 +3227,11 @@ export interface ResamplePropsNormalized
   extends GetTraitsNode,
     GetTraitsOperator,
     GetTraitsResample,
-    GetTraitsInclude {}
+    GetTraitsInclude,
+    Suffixed<GetTraitsSampler, "X">,
+    Suffixed<GetTraitsSampler, "Y">,
+    Suffixed<GetTraitsSampler, "Z">,
+    Suffixed<GetTraitsSampler, "W"> {}
 
 /**
  * Properties for {@link MathboxSelection.resample | resample}.
@@ -3201,7 +3241,11 @@ export interface ResampleProps
   extends SetTraitsNode,
     SetTraitsOperator,
     SetTraitsResample,
-    SetTraitsInclude {}
+    SetTraitsInclude,
+    Suffixed<SetTraitsSampler, "X">,
+    Suffixed<SetTraitsSampler, "Y">,
+    Suffixed<SetTraitsSampler, "Z">,
+    Suffixed<SetTraitsSampler, "W"> {}
 
 /**
  * Normalized properties for {@link MathboxSelection.retext | retext}.
@@ -3211,7 +3255,11 @@ export interface RetextPropsNormalized
   extends GetTraitsNode,
     GetTraitsOperator,
     GetTraitsResample,
-    GetTraitsInclude {}
+    GetTraitsInclude,
+    Suffixed<GetTraitsSampler, "X">,
+    Suffixed<GetTraitsSampler, "Y">,
+    Suffixed<GetTraitsSampler, "Z">,
+    Suffixed<GetTraitsSampler, "W"> {}
 
 /**
  * Properties for {@link MathboxSelection.retext | retext}.
@@ -3221,7 +3269,11 @@ export interface RetextProps
   extends SetTraitsNode,
     SetTraitsOperator,
     SetTraitsResample,
-    SetTraitsInclude {}
+    SetTraitsInclude,
+    Suffixed<SetTraitsSampler, "X">,
+    Suffixed<SetTraitsSampler, "Y">,
+    Suffixed<SetTraitsSampler, "Z">,
+    Suffixed<SetTraitsSampler, "W"> {}
 
 /**
  * Normalized properties for {@link MathboxSelection.reveal | reveal}.
@@ -3763,7 +3815,13 @@ export interface VolumePropsNormalized
     GetTraitsData,
     GetTraitsTexture,
     GetTraitsVoxel,
-    GetTraitsVolume {
+    GetTraitsVolume,
+    Suffixed<GetTraitsSpan, "X">,
+    Suffixed<GetTraitsSpan, "Y">,
+    Suffixed<GetTraitsSpan, "Z">,
+    Suffixed<GetTraitsSampler, "X">,
+    Suffixed<GetTraitsSampler, "Y">,
+    Suffixed<GetTraitsSampler, "Z"> {
   expr: VolumeEmitter | null;
 }
 
@@ -3777,7 +3835,13 @@ export interface VolumeProps
     SetTraitsData,
     SetTraitsTexture,
     SetTraitsVoxel,
-    SetTraitsVolume {
+    SetTraitsVolume,
+    Suffixed<SetTraitsSpan, "X">,
+    Suffixed<SetTraitsSpan, "Y">,
+    Suffixed<SetTraitsSpan, "Z">,
+    Suffixed<SetTraitsSampler, "X">,
+    Suffixed<SetTraitsSampler, "Y">,
+    Suffixed<SetTraitsSampler, "Z"> {
   expr?: VolumeEmitter;
 }
 


### PR DESCRIPTION
This PR adds types for more of the node properties. I think I have them all now.

### Background: traits and properties
Mathbox nodes get their properties from "traits". For example, `<grid />` has the following 16 traits:

```ts
export class Grid extends Primitive {
  static initClass() {
    this.traits = [
      "node",
      "object",
      "visible",
      "style",
      "line",
      "grid",
      "area",
      "position",
      "origin",
      "shade",
      "axis:x",
      "axis:y",
      "scale:x",
      "scale:y",
      "span:x",
      "span:y",
    ];
  /** rest of class */
}
```

Each trait defines a bunch of properties. For example, the [`axis` trait defines](https://github.com/unconed/mathbox/blob/527df839001080866eb6cac54f61f55bb4cb01da/src/primitives/types/traits.js#L124) two properties:

```ts
  axis: {
    detail: Types.int(1),
    crossed: Types.bool(false),
  },
```

### Aliasing
When `Grid` includes `"axis:x"` and `axis:y"` as traits, the axis properties get included twice with suffixes X and Y:
```ts
// Grid Properties
{
  detailX: number
  crossedX: boolean
  detailY: number
  crossedY: boolean
}
```

### Previous work
When I originally added Typescript definitions for mathbox (https://github.com/unconed/mathbox/commit/0665621b4318780d96dd9a73e45a38931fb06569) I did not understand how the above suffix aliasing worked, so I just skipped those properties. Consequently, `<grid>` and a bunch of other node types were missing a bunch of properties. This PR adds them in.