### PR TITLE
Add root(options, binds) function to API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
-### MathBox Changelog
+## MathBox Changelog
+
+### [unreleased]
+
+- Add a `root` function to the API with the same 2-argument interface as all
+  other primitives. The map provided to the first argument is passed to
+  `mathbox.set`, and the second argument is passed to `mathbox.bind`. `root`
+  returns the root node.
 
 ### 2.2.1
+
 - Add Typescript support for live properties and `bind`. [#43](https://github.com/unconed/mathbox/pull/43)
 
 ### 2.2.0

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -82,9 +82,9 @@ view
     width: 3,
   })
   .grid({
-    width: 2,  
+    width: 2,
     divideX: 20,
-    divideY: 10,        
+    divideY: 10,
   });
 ```
 
@@ -110,7 +110,7 @@ mathbox.select('axis').set('color', 'black');
 As the on-screen size of elements depends on the position of the camera, we can calibrate our units by setting the `focus` on the `<root>` to match the camera distance:
 
 ```javascript
-mathbox.set('focus', 3);
+mathbox.root({focus: 3});
 ```
 
 Which gives us:

--- a/examples/test/root.html
+++ b/examples/test/root.html
@@ -20,11 +20,10 @@
       - a minified version mathbox.min.js is also available;
       - recommend using a specific version (not @latest) in public sites
     -->
-    <!-- <script
-         type="text/javascript"
-         src="https://cdn.jsdelivr.net/npm/mathbox@latest/build/bundle/mathbox.js"
-         ></script> -->
-    <script type="text/javascript" src="../../build/bundle/mathbox.js"></script>
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/mathbox@latest/build/bundle/mathbox.js"
+    ></script>
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/mathbox@latest/build/mathbox.css"
@@ -73,9 +72,7 @@
       mathbox.root(
         { id: "mathbox-root" },
         {
-          focus: function (time, delta) {
-            return 5 * Math.sin(time * 0.5);
-          },
+          focus: (time, delta) => 5 * Math.sin(time * 0.5),
         }
       );
 

--- a/examples/test/root.html
+++ b/examples/test/root.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>MathBox - Empty</title>
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/three@0.137.0/build/three.min.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/three@0.137.0/examples/js/controls/OrbitControls.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="https://cdn.jsdelivr.net/npm/three@0.137.0/examples/js/controls/TrackballControls.js"
+    ></script>
+
+    <!--
+      - a minified version mathbox.min.js is also available;
+      - recommend using a specific version (not @latest) in public sites
+    -->
+    <!-- <script
+         type="text/javascript"
+         src="https://cdn.jsdelivr.net/npm/mathbox@latest/build/bundle/mathbox.js"
+         ></script> -->
+    <script type="text/javascript" src="../../build/bundle/mathbox.js"></script>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/mathbox@latest/build/mathbox.css"
+    />
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1" />
+  </head>
+  <body>
+    <script>
+      var mathbox = MathBox.mathBox({
+        plugins: ["core", "controls", "cursor", "mathbox"],
+        controls: {
+          klass: THREE.OrbitControls,
+        },
+      });
+      if (mathbox.fallback) throw "WebGL not supported";
+
+      var three = mathbox.three;
+      three.renderer.setClearColor(new THREE.Color(0xffffff), 1.0);
+      var camera = mathbox.camera({
+        proxy: true,
+        position: [0, 0, 3],
+      });
+      var view = mathbox.cartesian({
+        range: [
+          [-2, 2],
+          [-1, 1],
+        ],
+        scale: [2, 1],
+      });
+      view
+        .axis({
+          axis: 1,
+          width: 3,
+        })
+        .axis({
+          axis: 2,
+          width: 3,
+        })
+        .grid({
+          width: 2,
+          divideX: 20,
+          divideY: 10,
+        });
+
+      // Set a static property and a dynamic property.
+      mathbox.root(
+        { id: "mathbox-root" },
+        {
+          focus: function (time, delta) {
+            return 5 * Math.sin(time * 0.5);
+          },
+        }
+      );
+
+      // Add some data
+      var data = view.interval({
+        expr: function (emit, x, i, t) {
+          emit(x, Math.sin(x + t));
+        },
+        width: 64,
+        channels: 2,
+      });
+
+      // Draw a curve
+      var curve = view.line({
+        width: 5,
+        color: "#3090FF",
+      });
+    </script>
+  </body>
+</html>

--- a/src/stage/api.js
+++ b/src/stage/api.js
@@ -43,6 +43,11 @@ export class API {
         this[type] = (options, binds) => this.add(type, options, binds);
       }
     }
+    this["root"] = (options, binds) => {
+      root.set(options);
+      root.bind(binds);
+      return this._reset();
+    };
   }
 
   select(selector) {
@@ -166,7 +171,7 @@ export class API {
   }
   _reset() {
     let left;
-    return (left = this._up != null ? this._up.reset() : undefined) != null
+    return (left = this._up != null ? this._up._reset() : undefined) != null
       ? left
       : this;
   }

--- a/test/primitives/types/base/root.js
+++ b/test/primitives/types/base/root.js
@@ -1,28 +1,22 @@
 import * as MB from "../../../../src";
-import { smallPause } from "../../../test_utils";
 
 describe("primitives.types.base.root", () => {
-  it("reacts to changes in width", async () => {
+  it("returns the root from any selection", async () => {
+    const mathbox = MB.mathBox();
+    const root = mathbox.cartesian().root();
+
+    expect(root).toBe(mathbox);
+  });
+
+  it("reacts to changes in properties", async () => {
     const mathbox = MB.mathBox();
     const root = mathbox.root();
-    expect(root).toBe(mathbox);
 
-    // const array = cartesian.array({ width: 16 });
+    // default focus
+    expect(mathbox.get("focus")).toBe(1);
 
-    // const controller = array[0].controller;
-    // const rebuild = spyOn(controller, "rebuild").and.callThrough();
-
-    // expect(rebuild).toHaveBeenCalledTimes(0);
-    // expect(controller.space.width).toBe(16);
-
-    // array.set("width", 32);
-    // await smallPause();
-    // expect(rebuild).toHaveBeenCalledTimes(1);
-    // expect(controller.space.width).toBe(32);
-
-    // array.set("width", 24);
-    // await smallPause();
-    // expect(rebuild).toHaveBeenCalledTimes(2);
-    // expect(controller.space.width).toBe(24);
+    // set via root and see the change reflected in mathbox.
+    mathbox.root({ focus: 10 });
+    expect(mathbox.get("focus")).toBe(10);
   });
 });

--- a/test/primitives/types/base/root.js
+++ b/test/primitives/types/base/root.js
@@ -1,0 +1,28 @@
+import * as MB from "../../../../src";
+import { smallPause } from "../../../test_utils";
+
+describe("primitives.types.base.root", () => {
+  it("reacts to changes in width", async () => {
+    const mathbox = MB.mathBox();
+    const root = mathbox.root();
+    expect(root).toBe(mathbox);
+
+    // const array = cartesian.array({ width: 16 });
+
+    // const controller = array[0].controller;
+    // const rebuild = spyOn(controller, "rebuild").and.callThrough();
+
+    // expect(rebuild).toHaveBeenCalledTimes(0);
+    // expect(controller.space.width).toBe(16);
+
+    // array.set("width", 32);
+    // await smallPause();
+    // expect(rebuild).toHaveBeenCalledTimes(1);
+    // expect(controller.space.width).toBe(32);
+
+    // array.set("width", 24);
+    // await smallPause();
+    // expect(rebuild).toHaveBeenCalledTimes(2);
+    // expect(controller.space.width).toBe(24);
+  });
+});


### PR DESCRIPTION
This PR adds the `root()` function that I had been missing! The advantage here in a mathbox-react context is that you can set root properties now without messing with a `ref`. This simplifies my initialization code...

@ChristopherChudzicki , after this is in I think we can add a `Root` component to mathbox-react, yeah? Then all of the initial camera settings from the examples can be replaced with uses of the `Camera` component (with proxy set to true) and `Root` takes care of the `set()` calls.