### PR TITLE
specify types for "." export

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### MathBox Changelog
 
+### Unreleased
+
+- Support Typescript `moduleResolution: node16`.
+
 ### 2.3.0
 
 - improved TS defintions for color, vector, matrix, and quaternion based properties. [#55](https://github.com/unconed/mathbox/pull/55)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "module": "./build/esm/index.js",
   "exports": {
     ".": {
+      "types": "./build/esm/types.d.ts",
       "import": "./build/esm/index.js"
     },
     "./mathbox.css": {


### PR DESCRIPTION
This change allows Typescript to find type definitions when using the `exports` field, which is used when tsconfig's `moduleResolution` is set to `node16`.

See:
- NodeJS documentation for exports https://nodejs.org/api/packages.html#conditional-exports
- TS 4.7 blog post announcing support for `exports`. https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing it's example is a little more involved than what 
