### PR TITLE
replace RGBFormat with explicit undefined

### DIFF
--- a/src/render/buffer/memo.js
+++ b/src/render/buffer/memo.js
@@ -22,6 +22,7 @@ export class Memo extends RenderToTexture {
     const height = options.height || 1;
     const depth = options.depth || 1;
 
+    // RGBFormat was removed in r137 of ThreeJS
     //options.format = [null, THREE.LuminanceFormat, THREE.LuminanceAlphaFormat, THREE.RGBFormat, THREE.RGBAFormat][@channels]
     options.format = RGBAFormat;
     options.width = _width = items * width;

--- a/src/render/buffer/texture/datatexture.js
+++ b/src/render/buffer/texture/datatexture.js
@@ -67,7 +67,7 @@ export class DataTexture {
       null,
       CONST.LuminanceFormat,
       CONST.LuminanceAlphaFormat,
-      CONST.RGBFormat,
+      undefined // CONST.RGBFormat was removed in r137 of ThreeJS
       CONST.RGBAFormat,
     ][this.channels];
 


### PR DESCRIPTION
RGBFormat was removed in ThreeJS r137. Replacing with explicit undefined silences some build warnings and preserves existing behavior (including any bugs)

See https://github.com/unconed/mathbox/issues/64